### PR TITLE
Fix render_to_string options for Rails 5

### DIFF
--- a/lib/rqrcode-rails3.rb
+++ b/lib/rqrcode-rails3.rb
@@ -32,6 +32,6 @@ module RQRCode
   ActionController::Renderers.add :qrcode do |string, options|
     format = self.request.format.symbol
     data = RQRCode.render_qrcode(string, format, options)
-    self.response_body = render_to_string(:text => data, :template => nil)
+    self.response_body = render_to_string(:plain => data, :template => nil)
   end
 end


### PR DESCRIPTION
`render :text` is deprecated in Rails 5.0:

```
DEPRECATION WARNING: `render :text` is deprecated because it does not actually
render a `text/plain` response. Switch to `render plain: 'plain text'` to render
as `text/plain`, `render html: '<strong>HTML</strong>'` to render as
`text/html`, or `render body: 'raw'` to match the deprecated behavior and render
with the default Content-Type, which is `text/html`. (called from block (2
levels) in show at
/Users/jmromer/bikeindex/bike_index/app/controllers/bikes_controller.rb:40)
```

This patch silences this deprecation warning by updating the `render_to_string` invocation in the `:qrcode` renderer.